### PR TITLE
feat: add release-please CI action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,16 +2,28 @@ name: Release
 
 on:
   push:
-    tags: [ 'v*' ]
+    branches:
+      - main
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+    steps:
+      - id: release
+        uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: simple
 
   goreleaser:
     runs-on: ubuntu-latest
-
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ make
 
 You can also use make to clean your built artifact with `make clean`
 
+## Releasing
+
+
+This repo uses the [relase-please](https://github.com/googleapis/release-please) action. Release please leverages [conventional commits](https://www.conventionalcommits.org) formatting to automatically collect release notes to create the next semver tag. Once the release pr is merged release please will tag the next version and run goreleaser which will automatically build the binaries and attach them to the github release. The release pr will continue to collect changes since the last time a release was tagged.
+
+1. Create and merge any number of prs to main following conventional commits formatting. You can continue to merge changes to main and release please will continue to append changes to the open release pr since the last release was tagged.
+2. When you are ready to release the changes created in step 1, [merge the open release pr](https://github.com/derektamsen/hancock/labels/autorelease%3A%20pending). This will trigger CI to create a new tag and github release. CI will also run [goreleaser](https://goreleaser.com) which will build the binaries and update the github release with the artifacts.
+3. The changes merged in step 1 are now available on the [latest github release](https://github.com/derektamsen/hancock/releases/latest)
+
+
 ## Running
 This will be more complete later. However, for testing I am running the command directly with:
 ```


### PR DESCRIPTION
Add release-please to the release ci action. This will automatically collect
commits merged to main since the last release. Then once the release pr
is merged it will create a tag, create a github release, build the artifacts
using goreleaser, and post the artifacts to the github release.