### PR TITLE
chore: switch release-please to googleapis

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           release-type: simple
 


### PR DESCRIPTION
The release-please at `google-github-actions` has been deprecated and
moved to `googleapis`.